### PR TITLE
Activity enrichment now ignores missing schemas

### DIFF
--- a/src/backends/base.js
+++ b/src/backends/base.js
@@ -54,7 +54,7 @@ BaseBackend.prototype = {
       function(modelRef, done){
         var refs = references[modelRef];
         var modelClass = self.getClassFromRef(modelRef);
-        if (typeof(modelClass) === 'undefined') return done();
+        if (!modelClass || typeof(modelClass) === 'undefined') return done();
         if (typeof(objects[modelRef]) === 'undefined') objects[modelRef] = {};
         self.loadFromStorage(modelClass, refs, function(err, objectsIds) {
           for(var k in objectsIds){

--- a/src/backends/mongoose.js
+++ b/src/backends/mongoose.js
@@ -33,15 +33,21 @@ Backend.prototype.loadFromStorage = function(modelClass, objectsIds, callback) {
 };
 
 Backend.prototype.getClassFromRef = function(ref) {
-  // TODO: raise error if this.getMongoose returns undefined
-  // it means user forgot to call setupMongoose
+  
   var mongoose = this.getMongoose();
-  return mongoose.model(ref);
-}
+
+  try {
+    var model = mongoose.model(ref);
+    return model;
+  } catch( err ) {
+    return null;
+  }
+
+};
 
 Backend.prototype.getIdFromRef = function(ref) {
   return ref.split(':')[1];
-}
+};
 
 function getReferencePaths(paths) {
   var names = [];

--- a/test/backends/mongoose.mocha.js
+++ b/test/backends/mongoose.mocha.js
@@ -86,14 +86,15 @@ describe('Backend', function() {
         .catch(done);
     });
 
-    it('enrich missing model', function(done) {
-      var activity = {'object': 'user:42'};
-      backend.enrichActivities([activity])
-        .then(done)
-        .catch(function(err) {
-          (err).should.be.an.instanceOf(Error);
-          done();
-        });
+    it('skips missing model', function(done) {
+        var activity = {'object': 'user:42'};
+        backend.enrichActivities([activity])
+            .then(function( enriched ) {
+                enriched.should.length(1);
+                enriched[0].should.have.property('object', 'user:42');
+                done();
+            })
+            .catch(done);
     });
 
     it('dont enrich origin field', function(done) {


### PR DESCRIPTION
Before, when the activity enricher found a token that doesn't have
a matching schema, a MissingSchemaError error would be thrown.

This commit changes the enrichment process to ignore values for
which a matching schema can't be found. This will allow us to pass
activities to the enricher without having to worry about values that
don't need to be enriched in the first place.
